### PR TITLE
Usability: Improve "tools/mpy_cross_all" to invoke the "mpy-cross" program coming from the mpy_cross distribution

### DIFF
--- a/tools/mpy_cross_all.py
+++ b/tools/mpy_cross_all.py
@@ -1,38 +1,99 @@
 #!/usr/bin/env python3
-import argparse
+#
+# Motivation
+# - https://github.com/micropython/micropython/issues/3040
+# - https://github.com/micropython/micropython/pull/3057
+# - https://github.com/micropython/micropython/issues/4955
+#
 import os
 import os.path
+import argparse
+import shlex
+import subprocess
 
-argparser = argparse.ArgumentParser(description="Compile all .py files to .mpy recursively")
-argparser.add_argument("-o", "--out", help="output directory (default: input dir)")
-argparser.add_argument("--target", help="select MicroPython target config")
-argparser.add_argument("-mcache-lookup-bc", action="store_true", help="cache map lookups in the bytecode")
-argparser.add_argument("dir", help="input directory")
-args = argparser.parse_args()
+try:
+    import mpy_cross
+    USE_MPY_CROSS_WRAPPER = True
+except ImportError:
+    USE_MPY_CROSS_WRAPPER = False
+
 
 TARGET_OPTS = {
     "unix": "-mcache-lookup-bc",
     "baremetal": "",
 }
 
-args.dir = args.dir.rstrip("/")
 
-if not args.out:
-    args.out = args.dir
+def read_args():
+    argparser = argparse.ArgumentParser(description="Compile all .py files to .mpy recursively")
+    argparser.add_argument("-o", "--out", help="output directory (default: input dir)")
+    argparser.add_argument("--target", help="select MicroPython target config")
+    argparser.add_argument("-mcache-lookup-bc", action="store_true", help="cache map lookups in the bytecode")
+    argparser.add_argument("dir", help="input directory")
+    args = argparser.parse_args()
 
-path_prefix_len = len(args.dir) + 1
+    args.dir = args.dir.rstrip("/")
 
-for path, subdirs, files in os.walk(args.dir):
-    for f in files:
-        if f.endswith(".py"):
-            fpath = path + "/" + f
-            #print(fpath)
-            out_fpath = args.out + "/" + fpath[path_prefix_len:-3] + ".mpy"
+    if not args.out:
+        args.out = args.dir
+
+    return args
+
+
+def invoke_mpy_cross(arglist):
+
+    # MicroPython mpy-cross distribution
+    # https://pypi.org/project/mpy-cross/
+    if USE_MPY_CROSS_WRAPPER:
+        mpy_cross_args = shlex.split(arglist)
+        outcome = mpy_cross.run(*mpy_cross_args, stdout=subprocess.PIPE, stderr=subprocess.PIPE)
+        outcome.wait()
+        stdout, stderr = outcome.communicate()
+        if outcome.returncode != 0:
+            print('ERROR: Invoking "mpy_cross.run()" failed')
+            cmd = '{} {}'.format(mpy_cross.mpy_cross, ' '.join(mpy_cross_args))
+            print('ERROR: The command was: {}'.format(cmd))
+            print()
+            print('STDOUT:\n', stdout.decode())
+            print('STDERR:\n', stderr.decode())
+            raise RuntimeError('Invoking "mpy_cross.run()" failed')
+
+    # os.system(mpy-cross ...)
+    else:
+        cmd = "mpy-cross {}".format(arglist)
+        res = os.system(cmd)
+        if res != 0:
+            print('ERROR: Invoking "mpy-cross" directly failed')
+            print('ERROR: The command was: {}'.format(cmd))
+            raise RuntimeError('Invoking "mpy-cross" failed')
+
+
+def run():
+    args = read_args()
+
+    path_prefix_len = len(args.dir) + 1
+
+    for path, subdirs, files in os.walk(args.dir):
+        for filepath in files:
+            if not filepath.endswith(".py"):
+                continue
+
+            fpath_py = os.path.join(path, filepath)
+            fpath_mpy = fpath_py[path_prefix_len:-3] + ".mpy"
+
+            out_fpath = os.path.join(args.out, fpath_mpy)
+
+            # Create output directory gracefully.
             out_dir = os.path.dirname(out_fpath)
             if not os.path.isdir(out_dir):
                 os.makedirs(out_dir)
-            cmd = "mpy-cross -v -v %s -s %s %s -o %s" % (TARGET_OPTS.get(args.target, ""),
-                fpath[path_prefix_len:], fpath, out_fpath)
-            #print(cmd)
-            res = os.system(cmd)
-            assert res == 0
+
+            target_config = TARGET_OPTS.get(args.target, "")
+            fname = fpath_py[path_prefix_len:]
+
+            mpy_cross_args = "-v -v {target_config} -s {fname} {fpath_py} -o {out_fpath}".format(**locals())
+            invoke_mpy_cross(mpy_cross_args)
+
+
+if __name__ == '__main__':
+    run()


### PR DESCRIPTION
Dear @pfalcon, @dpgeorge, @stinos, @dhylands and all maintainers of good faith in MicroPython tooling,

first things first: Thank you so much for your amazing work on MicroPython and its ecosystem - you know who you are.

## Introduction
Coming from https://github.com/micropython/micropython/issues/4955 and building upon https://github.com/micropython/micropython/issues/3040 and https://github.com/micropython/micropython/issues/3057, we enabled `tools/mpy_cross_all.py` to invoke the `mpy-cross` program through the fine [`mpy-cross` distribution package](https://pypi.org/project/mpy-cross/).

## Setup
The operator will be able to decide to selectively install specific versions of `mpy-cross` like
```bash
source .venv2/bin/activate
pip install mpy-cross=1.9.4
```
into the Python environment running on her workstation.

## Usage

### Description
When running it from a Python environment where the `mpy_cross` modules is installed, `mpy_cross_all.py` will attempt to invoke `mpy-cross` from the `mpy_cross` distribution.

Otherwise, it will go down the established route of invoking `mpy-cross` directly, essentially expecting it to reside somewhere on `$PATH`.

### Synopsis
```bash
source .venv2/bin/activate
time python tools/mpy_cross_all.py --out dist-packages-mpy dist-packages

real	0m0.439s
user	0m0.152s
sys	0m0.247s
```

We hope you like this.

With kind regards,
Andreas.
